### PR TITLE
Updated backend to support `/auth/me` state calls on the frontend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Installs all dependencies
 
 To run the server, by default this creates a server running on `http://localhost:5000`
 
-
 ### `npm run prepush:fix`
 
 Checks if linting and prettier and Typescript compilation checks pass, AND auto-fixes problems.
@@ -23,7 +22,6 @@ Checks if linting and prettier and Typescript compilation checks pass, AND auto-
 ### `npm run prepush`
 
 Checks if linting and prettier and Typescript compilation checks pass.
-
 
 ### `npm test`
 
@@ -33,9 +31,19 @@ Runs all unit tests
 
 Runs all e2e tests, requires a running DB.
 
+### `npm run seed:run`
+
+Runs the seed files so that you have data in your database for development! Only needs to be run once.
+
 ### `npm run migration`
+
 Runs all migrations in migrations folder that have not been recorded yet.
 
 ### `npm run typeorm migration:generate -- -n [name]`
+
 Automatically generates a migration based off changes to TypeORM entities.
 Example usage: `npm run typeorm migration:generate -- -n "createdUserProfiles"`
+
+### `npm run schema:drop`
+
+Drops your database. Do not do this unless you really need to!

--- a/migrations/1632399687740-removedIsClaimedFromUser.ts
+++ b/migrations/1632399687740-removedIsClaimedFromUser.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class removedIsClaimedFromUser1632399687740
+  implements MigrationInterface
+{
+  name = 'removedIsClaimedFromUser1632399687740';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "isClaimed"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "isClaimed" boolean NOT NULL`,
+    );
+  }
+}

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -8,7 +8,6 @@ const mockUser: User = {
   id: 1,
   email: 'test@test.com',
   role: Role.ADMIN,
-  isClaimed: true,
 };
 
 const serviceMock: Partial<AuthService> = {

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -11,7 +11,6 @@ const mockUser: User = {
   id: 1,
   email: 'test@test.com',
   role: Role.RESEARCHER,
-  isClaimed: false,
 };
 
 const mockCognitoService = {

--- a/src/auth/guards/roles.guard.spec.ts
+++ b/src/auth/guards/roles.guard.spec.ts
@@ -8,7 +8,6 @@ const mockUser = (role: Role): User => ({
   id: 1,
   email: 'test@test.com',
   role,
-  isClaimed: true,
 });
 
 const mockContext = (user?: User): Partial<ExecutionContext> => ({

--- a/src/auth/middleware/authentication.middleware.spec.ts
+++ b/src/auth/middleware/authentication.middleware.spec.ts
@@ -7,7 +7,6 @@ const mockUser: User = {
   id: 1,
   email: 'test@test.com',
   role: Role.ADMIN,
-  isClaimed: false,
 };
 
 const mockAuthService: Partial<AuthService> = {

--- a/src/seeds/seed-users.ts
+++ b/src/seeds/seed-users.ts
@@ -11,9 +11,12 @@ export default class CreateUsers implements Seeder {
       .into(User)
       .values([
         {
-          email: 'test@test.com',
+          email: 'c4cneu.jpal+admin@gmail.com',
           role: Role.ADMIN,
-          isClaimed: true,
+        },
+        {
+          email: 'c4cneu.jpal+researcher@gmail.com',
+          role: Role.RESEARCHER,
         },
       ])
       .execute();

--- a/src/users/types/user.entity.ts
+++ b/src/users/types/user.entity.ts
@@ -19,7 +19,4 @@ export class User {
     default: Role.ADMIN,
   })
   role: Role;
-
-  @Column()
-  isClaimed: boolean;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -8,7 +8,6 @@ const mockUser: User = {
   id: 1,
   email: 'test@test.com',
   role: Role.ADMIN,
-  isClaimed: true,
 };
 
 const serviceMock: Partial<UsersService> = {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -11,7 +11,6 @@ const mockUser: User = {
   id: 1,
   email: 'test@test.com',
   role: Role.ADMIN,
-  isClaimed: false,
 };
 
 const mockUserRepository: Partial<Repository<User>> = {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -63,7 +63,6 @@ describe('UsersService', () => {
       id: 1,
       email: mockUser.email,
       role: mockUser.role,
-      isClaimed: false,
     });
     expect(mockAwsCreateUserService.adminCreateUser).toHaveBeenCalledWith(
       mockUser.email,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -24,7 +24,6 @@ export class UsersService {
       const user = this.userRepository.create({
         email,
         role,
-        isClaimed: false,
       });
       return this.userRepository.save(user);
     } catch (error) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -8,7 +8,6 @@ import { overrideExternalDependencies } from './mockProviders';
 const initialUser: Omit<User, 'id'> = {
   email: 'test@test.com',
   role: Role.ADMIN,
-  isClaimed: false,
 };
 
 describe('Example e2e', () => {

--- a/test/pact/pact-provider-config-options.service.ts
+++ b/test/pact/pact-provider-config-options.service.ts
@@ -38,10 +38,8 @@ export class PactProviderConfigOptionsService
 
     return {
       requestFilter: (req, res, next) => {
-        req.headers.MY_SPECIAL_HEADER = 'my special value';
-
         // e.g. ADD Bearer token
-        req.headers.authorization = `Bearer ${token}`;
+        if (token) req.headers.authorization = `Bearer ${token}`;
         next();
       },
 
@@ -57,22 +55,29 @@ export class PactProviderConfigOptionsService
           });
           return 'Animals removed to the db';
         },
-        'Has some animals': async () => {
-          token = '1234';
-          //this.animalRepository.importData();
-
-          return 'Animals added to the db';
+        'signed in as an researcher': async () => {
+          await this.userRepository.clear();
+          await this.userRepository.save({
+            email: 'c4cneu.jpal+researcher@gmail.com',
+            role: Role.RESEARCHER,
+            isClaimed: true,
+          });
+          token = JSON.stringify({ email: 'c4cneu.jpal+researcher@gmail.com' });
+          return 'Request sent as a user authorized as a researcher';
         },
-        'Has an animal with ID 1': async () => {
-          token = '1234';
-          //this.animalRepository.importData();
-
-          return 'Animals added to the db';
+        'signed in as an admin': async () => {
+          await this.userRepository.clear();
+          await this.userRepository.save({
+            email: 'c4cneu.jpal+admin@gmail.com',
+            role: Role.ADMIN,
+            isClaimed: true,
+          });
+          token = JSON.stringify({ email: 'c4cneu.jpal+admin@gmail.com' });
+          return 'Request sent as a user authorized as an admin';
         },
         'is not authenticated': async () => {
-          token = '';
-
-          return 'Invalid bearer token generated';
+          token = undefined;
+          return 'No authorization token sent';
         },
       },
 

--- a/test/pact/pact-provider-config-options.service.ts
+++ b/test/pact/pact-provider-config-options.service.ts
@@ -45,13 +45,11 @@ export class PactProviderConfigOptionsService
 
       stateHandlers: {
         nothing: async () => {
-          //this.animalRepository.clear();
           token = '1234';
           await this.userRepository.clear();
           await this.userRepository.save({
             email: 'test@test.com',
             role: Role.ADMIN,
-            isClaimed: true,
           });
           return 'Animals removed to the db';
         },
@@ -60,7 +58,6 @@ export class PactProviderConfigOptionsService
           await this.userRepository.save({
             email: 'c4cneu.jpal+researcher@gmail.com',
             role: Role.RESEARCHER,
-            isClaimed: true,
           });
           token = JSON.stringify({ email: 'c4cneu.jpal+researcher@gmail.com' });
           return 'Request sent as a user authorized as a researcher';
@@ -70,7 +67,6 @@ export class PactProviderConfigOptionsService
           await this.userRepository.save({
             email: 'c4cneu.jpal+admin@gmail.com',
             role: Role.ADMIN,
-            isClaimed: true,
           });
           token = JSON.stringify({ email: 'c4cneu.jpal+admin@gmail.com' });
           return 'Request sent as a user authorized as an admin';

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -10,7 +10,6 @@ import { overrideExternalDependencies } from './mockProviders';
 const initialAdminUser: Omit<User, 'id'> = {
   email: 'test@test.com',
   role: Role.RESEARCHER,
-  isClaimed: true,
 };
 
 describe('Users e2e', () => {

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -53,7 +53,6 @@ describe('Users e2e', () => {
         id: expect.any(Number),
         email: 'test.createuser@test.com',
         role: Role.RESEARCHER,
-        isClaimed: false,
       }),
     );
   });
@@ -74,7 +73,6 @@ describe('Users e2e', () => {
         id: expect.any(Number),
         email: 'test.createuser@test.com',
         role: Role.ADMIN,
-        isClaimed: false,
       }),
     );
   });


### PR DESCRIPTION
Does some general cleanup to support auth calls on the frontend (Linked PR: https://github.com/Code-4-Community/jpal-frontend/pull/41)

- Removed isClaimed field from the users entity and created migration
  - We dont need this anymore because cognito does this for us
- Added pact states for frontend tests to use
- Added a couple more things to the README 