### PR TITLE
Add port to .env file

### DIFF
--- a/example.env
+++ b/example.env
@@ -15,3 +15,5 @@ AWS_USER_POOL_REGION=xxx
 
 PACT_BROKER_TOKEN=xxx
 PACT_BROKER_URL=https://c4cneu.pactflow.io
+
+PORT=xxxx

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,6 @@ async function bootstrap() {
     tracesSampleRate: 1.0,
   });
 
-  await app.listen(5000);
+  await app.listen(process.env.PORT || 5000);
 }
 bootstrap();


### PR DESCRIPTION
Added PORT as an env variable so that anyone can (optionally) change the port that the server runs on. 

If a PORT value is not provided, defaults to 5000. Therefore this should not affect any existing code.