### PR TITLE
Added create:migration to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Runs all e2e tests, requires a running DB.
 
 ### `npm run seed`
 
-Runs the seed files in the correct order so that you have data in your database for development! 
+Runs the seed files in the correct order so that you have data in your database for development!
 
 ## `npm run seed:run -- -s <specific seeder class>`
 
@@ -43,10 +43,10 @@ Runs a specific seed file.
 
 Runs all migrations in migrations folder that have not been recorded yet.
 
-### `npm run typeorm migration:generate -- -n [name]`
+### `npm run miration:create -- [name]`
 
 Automatically generates a migration based off changes to TypeORM entities.
-Example usage: `npm run typeorm migration:generate -- -n "createdUserProfiles"`
+Example usage: `npm run miration:create -- -n "createdUserProfiles"`
 
 ### `npm run schema:drop`
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:pact": "jest --config ./test/jest-pact.json",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js --config ormconfig.ts",
     "migration": "npm run build && npm run typeorm migration:run",
+    "migration:create": "npm run typeorm migration:generate -- -n",
     "migration:revert": "npm run build && npm run typeorm migration:revert",
     "seed:config": "ts-node ./node_modules/typeorm-seeding/dist/cli.js config",
     "seed:run": "ts-node ./node_modules/typeorm-seeding/dist/cli.js seed",


### PR DESCRIPTION
### Summary 
The create migration script was kinda annoying and inconsistent with how other things were, so now instead of the long typeORM script you just have to run `npm run migration:create -- [name]` to create a new migration. I tested it, it works. 