### PR TITLE
Update GET /survey for researchers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "jpal-backend",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
@@ -16469,9 +16468,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
           "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "chalk": {
           "version": "4.1.1",
@@ -17727,9 +17724,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
       "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",

--- a/src/assignment/assignment.service.spec.ts
+++ b/src/assignment/assignment.service.spec.ts
@@ -3,7 +3,7 @@ import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Assignment } from './types/assignment.entity';
 import { AssignmentService } from './assignment.service';
-import { mockSurvey, mockSurveyTemplate } from '../survey/survey.service.spec';
+import { mockSurvey, mockSurveyTemplate } from '../survey/survey.controller.spec';
 import { reviewerExamples } from '../reviewer/reviewer.examples';
 import { youthExamples } from '../youth/youth.examples';
 import { AssignmentStatus } from './types/assignmentStatus';

--- a/src/survey/survey.controller.spec.ts
+++ b/src/survey/survey.controller.spec.ts
@@ -2,13 +2,36 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SurveyController } from './survey.controller';
 import { SurveyService } from './survey.service';
 import { Survey } from './types/survey.entity';
-import { mockSurvey, mockSurveyTemplate } from './survey.service.spec';
-import { mockUser } from '../user/user.service.spec';
+import { mockResearcher, mockUser } from '../user/user.service.spec';
 import { User } from 'src/user/types/user.entity';
+import { SurveyTemplate } from 'src/surveyTemplate/types/surveyTemplate.entity';
 
-const listMockSurveys: Survey[] = [];
+export const UUID = '123e4567-e89b-12d3-a456-426614174000';
 
-const UUID = '123e4567-e89b-12d3-a456-426614174000';
+export const mockSurveyTemplate: SurveyTemplate = {
+  id: 1,
+  creator: mockUser,
+  questions: [],
+};
+
+export const mockSurvey: Survey = {
+  id: 1,
+  uuid: UUID,
+  surveyTemplate: mockSurveyTemplate,
+  name: "Survey 1",
+  creator: mockUser
+}
+
+export const mockSurvey2: Survey = {
+  id: 2,
+  uuid: UUID,
+  surveyTemplate: mockSurveyTemplate,
+  name: "Survey 2",
+  creator: mockResearcher
+}
+
+export const listMockSurveys: Survey[] = [mockSurvey, mockSurvey2]
+
 export const mockSurveyService: Partial<SurveyService> = {
   async create(surveyTemplateId: number, name: string, creator: User): Promise<Survey> {
     return {
@@ -23,7 +46,8 @@ export const mockSurveyService: Partial<SurveyService> = {
     return mockSurvey;
   },
 
-  findAllSurveys: jest.fn(() => Promise.resolve(listMockSurveys)),
+  findAllSurveysByUser: jest.fn(() => Promise.resolve([mockSurvey])),
+  getAllSurveys: jest.fn(() => Promise.resolve(listMockSurveys)),
 };
 
 describe('SurveyController', () => {
@@ -63,7 +87,11 @@ describe('SurveyController', () => {
     expect(survey).toEqual(mockSurvey);
   });
   it('should find all the surveys created by the user', async () => {
-    expect(await controller.findAllSurveys(mockUser)).toEqual(listMockSurveys);
-    expect(mockSurveyService.findAllSurveys).toHaveBeenCalled();
+    expect(await controller.findAllSurveys(mockUser)).toEqual([mockSurvey]);
+    expect(mockSurveyService.findAllSurveysByUser).toHaveBeenCalled();
   });
+  it('should get all surveys for researcher', async () => {
+    expect(await controller.findAllSurveys(mockResearcher)).toEqual(listMockSurveys);
+    expect(mockSurveyService.getAllSurveys).toHaveBeenCalled();
+  })
 });

--- a/src/survey/survey.controller.spec.ts
+++ b/src/survey/survey.controller.spec.ts
@@ -74,7 +74,7 @@ describe('SurveyController', () => {
   it('should create a user', async () => {
     const survey = await controller.create(
       {
-        name: 'Test Survey',
+        name: 'Survey 1',
         surveyTemplateId: 1,
       },
       mockUser,

--- a/src/survey/survey.controller.ts
+++ b/src/survey/survey.controller.ts
@@ -45,6 +45,10 @@ export class SurveyController {
   @Get()
   @Auth(Role.ADMIN, Role.RESEARCHER)
   findAllSurveys(@ReqUser() user: User): Promise<Survey[]> {
-    return this.surveyService.findAllSurveys(user);
+    if(user.role == Role.ADMIN) {
+      return this.surveyService.findAllSurveysByUser(user); 
+    } else if(user.role == Role.RESEARCHER) {
+      return this.surveyService.getAllSurveys();
+    }
   }
 }

--- a/src/survey/survey.service.spec.ts
+++ b/src/survey/survey.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SurveyService } from './survey.service';
 import { Survey } from './types/survey.entity';
-import { mockUser } from '../user/user.service.spec';
+import { mockResearcher, mockUser } from '../user/user.service.spec';
 import { DeepPartial, Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SurveyTemplate } from '../surveyTemplate/types/surveyTemplate.entity';
@@ -10,24 +10,7 @@ import { Assignment } from '../assignment/types/assignment.entity';
 import { Youth } from '../youth/types/youth.entity';
 import { Reviewer } from '../reviewer/types/reviewer.entity';
 import { CreateBatchAssignmentsDto } from './dto/create-batch-assignments.dto';
-
-export const mockSurveyTemplate: SurveyTemplate = {
-  id: 1,
-  creator: mockUser,
-  questions: [],
-};
-
-const UUID = '123e4567-e89b-12d3-a456-426614174000';
-
-export const mockSurvey: Survey = {
-  id: 1,
-  uuid: UUID,
-  name: 'Test Survey',
-  surveyTemplate: mockSurveyTemplate,
-  creator: mockUser,
-};
-
-const listMockSurveys: Survey[] = [mockSurvey];
+import { listMockSurveys, mockSurvey, mockSurveyTemplate, UUID } from './survey.controller.spec';
 
 export const mockSurveyRepository: Partial<Repository<Survey>> = {
   create(survey?: DeepPartial<Survey> | DeepPartial<Survey>[]): any {
@@ -114,7 +97,12 @@ describe('SurveyService', () => {
   });
 
   it('should fetch all surveys created by current user', async () => {
-    const goodResponse = await service.findAllSurveys(mockUser);
+    const goodResponse = await service.findAllSurveysByUser(mockUser);
+    expect(goodResponse).toEqual([mockSurvey]);
+  });
+
+  it('should fetch all surveys', async () => {
+    const goodResponse = await service.getAllSurveys();
     expect(goodResponse).toEqual(listMockSurveys);
   });
 

--- a/src/survey/survey.service.spec.ts
+++ b/src/survey/survey.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SurveyService } from './survey.service';
 import { Survey } from './types/survey.entity';
 import { mockResearcher, mockUser } from '../user/user.service.spec';
-import { DeepPartial, Repository } from 'typeorm';
+import { DeepPartial, FindConditions, FindManyOptions, Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SurveyTemplate } from '../surveyTemplate/types/surveyTemplate.entity';
 import { MockRepository } from '../../test/db/MockRepository';
@@ -26,7 +26,11 @@ export const mockSurveyRepository: Partial<Repository<Survey>> = {
   findOne(): any {
     return undefined;
   },
-  find(): Promise<Survey[]> {
+  find(options?: FindManyOptions<Survey> | FindConditions<Survey>): Promise<Survey[]> {
+    // this checks to see if a find call is trying to filter the results by creator
+    if (options && 'where' in options) {
+      return Promise.resolve([mockSurvey]);
+    }
     return Promise.resolve(listMockSurveys);
   },
   findOneOrFail(): Promise<Survey> {

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -37,10 +37,14 @@ export class SurveyService {
     return this.surveyRepository.findOneOrFail({ uuid });
   }
 
-  async findAllSurveys(user: User): Promise<Survey[]> {
+  async findAllSurveysByUser(user: User): Promise<Survey[]> {
     return this.surveyRepository.find({
       where: { creator: user },
     });
+  }
+
+  async getAllSurveys(): Promise<Survey[]> {
+    return this.surveyRepository.find();
   }
 
   /**

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -11,12 +11,20 @@ import { UserService } from './user.service';
 export const mockUser: User = {
   id: 1,
   email: 'test@test.com',
-  firstName: 'test',
+  firstName: 'William',
   lastName: 'user',
   role: Role.ADMIN,
 };
 
-const listMockUsers: User[] = [mockUser];
+export const mockResearcher: User = {
+  id: 2,
+  email: 'test@test.com',
+  firstName: 'Paige',
+  lastName: 'Turner',
+  role: Role.RESEARCHER,
+}
+
+const listMockUsers: User[] = [mockUser, mockResearcher];
 
 const mockUserRepository: Partial<Repository<User>> = {
   create(user?: DeepPartial<User> | DeepPartial<User>[]): any {


### PR DESCRIPTION
Edited SurveyController and SurveyService so that researchers receive a list of all surveys created when they make a GET request to the /survey endpoint.

Testing Steps
- Unit tests in survey.service.spec.ts and survey.controller.spec.ts
- Manual testing not done yet