### PR TITLE
Survey Service Error Handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "jpal-backend",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
@@ -14930,7 +14931,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
           "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "chalk": {
           "version": "4.1.1",
@@ -16126,7 +16129,9 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
       "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "ansi-colors": {
       "version": "4.1.1",

--- a/src/survey/survey.service.spec.ts
+++ b/src/survey/survey.service.spec.ts
@@ -43,22 +43,16 @@ export const mockSurveyRepository: Partial<Repository<Survey>> = {
   save<T>(survey): T {
     return survey;
   },
-  findOne(): any {
-    return undefined;
-  },
   find(): Promise<Survey[]> {
     return Promise.resolve(listMockSurveys);
   },
-  findOneOrFail(): Promise<Survey> {
+  findOne(): Promise<Survey> {
     return Promise.resolve(mockSurvey);
   },
 };
 
 export const mockSurveyTemplateRepository: Partial<Repository<SurveyTemplate>> = {
   async findOne() {
-    return mockSurveyTemplate;
-  },
-  async findOneOrFail(): Promise<SurveyTemplate> {
     return mockSurveyTemplate;
   },
 };

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -29,9 +29,12 @@ export class SurveyService {
   ) {}
 
   async create(surveyTemplateId: number, name: string, creator: User) {
-    const surveyTemplate = await this.surveyTemplateRepository.findOneOrFail({
+    const surveyTemplate = await this.surveyTemplateRepository.findOne({
       id: surveyTemplateId,
     });
+    if (!surveyTemplate) {
+      throw new BadRequestException('Requested survey template does not exist');
+    }
     return this.surveyRepository.create({
       surveyTemplate,
       name,
@@ -41,7 +44,11 @@ export class SurveyService {
   }
 
   async getByUUID(uuid: string): Promise<Survey> {
-    return this.surveyRepository.findOneOrFail({ uuid });
+    const survey = this.surveyRepository.findOne({ where: { uuid } });
+    if (!survey) {
+      throw new BadRequestException('Requested survey does not exist');
+    }
+    return survey;
   }
 
   async findAllSurveys(user: User): Promise<Survey[]> {
@@ -89,7 +96,14 @@ export class SurveyService {
         'surveyTemplate.questions.options',
       ],
     });
+    if (!survey) {
+      throw new BadRequestException('Requested survey does not exist');
+    }
+
     const reviewer = await this.reviewerRepository.findOne({ where: { uuid: reviewerUuid } });
+    if (!reviewer) {
+      throw new BadRequestException('Requested reviewer does not exist');
+    }
 
     const assignmentsForReviewer = survey.assignments.filter(
       (assignment) =>


### PR DESCRIPTION
## Summary 
- Replaced instances of FindOneOrFail in the survey service with FindOne and a thrown 400 error to avoid any 500 errors. 
- Added some checks for bad input to get reviewer survey