### PR TITLE
Created PATCH assignment endpoint to mark an assignment as in progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "jpal-backend",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
@@ -14930,7 +14931,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
           "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "chalk": {
           "version": "4.1.1",
@@ -16126,7 +16129,9 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
       "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "ansi-colors": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "npm run prepush",
     "prepush:fix": "npm run format && tsc --noEmit && npm run lint",
     "prepush": "npm run format:check && tsc --noEmit && npm run lint:check",
-    "test": "jest",
+    "test": "jest -w 1",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check": "npm run prepush",
     "prepush:fix": "npm run format && tsc --noEmit && npm run lint",
     "prepush": "npm run format:check && tsc --noEmit && npm run lint:check",
-    "test": "jest -w 1",
+    "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/src/assignment/assignment.controller.spec.ts
+++ b/src/assignment/assignment.controller.spec.ts
@@ -5,9 +5,8 @@ import { AssignmentController } from './assignment.controller';
 import { AssignmentService } from './assignment.service';
 import {
   assignment_UUID,
-  incompleteMockAssignment,
+  incompleteMockAssignment, inProgressMockAssignment,
   mockAssignment,
-  mockAssignment2,
   mockResponses,
 } from './assignment.service.spec';
 import { Assignment } from './types/assignment.entity';
@@ -20,7 +19,7 @@ const mockAssignmentService: Partial<AssignmentService> = {
     return incompleteMockAssignment;
   },
   async start(): Promise<Assignment> {
-    return mockAssignment;
+    return inProgressMockAssignment;
   },
 };
 
@@ -70,6 +69,6 @@ describe('AssignmentController', () => {
 
   it('should mark an assignment as in progress', async () => {
     const assignment = await controller.start(assignment_UUID);
-    expect(assignment).toEqual(mockAssignment);
+    expect(assignment).toEqual(inProgressMockAssignment);
   });
 });

--- a/src/assignment/assignment.controller.spec.ts
+++ b/src/assignment/assignment.controller.spec.ts
@@ -1,17 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import exp from 'constants';
 import { mock } from 'jest-mock-extended';
 import { mockSurveyService } from '../survey/survey.controller.spec';
 import { SurveyService } from '../survey/survey.service';
 import { AssignmentController } from './assignment.controller';
 import { AssignmentService } from './assignment.service';
-import { AssignmentStatus } from './types/assignmentStatus';
 import {
   assignment_UUID,
+  inProgressMockAssignment,
   mockAssignment,
   mockResponses,
-  inProgressMockAssignment,
 } from './assignment.service.spec';
+import { AssignmentStatus } from './types/assignmentStatus';
 
 const mockAssignmentService = mock<AssignmentService>();
 
@@ -47,7 +46,7 @@ describe('AssignmentController', () => {
   it('should fail to complete an assignment when given a bad ID', async () => {
     expect.assertions(1);
     mockAssignmentService.getByUuid.mockResolvedValue(undefined);
-    expect(controller.complete('bad!', mockCompleteAssignmentDto)).rejects.toThrow();
+    await expect(controller.complete('bad!', mockCompleteAssignmentDto)).rejects.toThrow();
   });
 
   it('should complete an assignment', async () => {
@@ -58,11 +57,15 @@ describe('AssignmentController', () => {
     expect(assignment).toEqual(mockAssignment);
   });
 
-  it('should mark an assignment as in progress', () => {
-    expect(controller.start('bad!')).rejects.toThrow();
+  it('should fail to start an assignment that does not exist', async () => {
+    expect.assertions(1);
+    mockAssignmentService.getByUuid.mockResolvedValue(undefined);
+    await expect(controller.start('bad!')).rejects.toThrow();
   });
 
   it('should mark an assignment as in progress', async () => {
+    expect.assertions(1);
+    mockAssignmentService.getByUuid.mockResolvedValue(mockAssignment);
     mockAssignmentService.start.mockResolvedValue(inProgressMockAssignment);
     const assignment = await controller.start(assignment_UUID);
     expect(assignment.status).toEqual(AssignmentStatus.IN_PROGRESS);

--- a/src/assignment/assignment.controller.spec.ts
+++ b/src/assignment/assignment.controller.spec.ts
@@ -5,6 +5,7 @@ import { AssignmentController } from './assignment.controller';
 import { AssignmentService } from './assignment.service';
 import {
   assignment_UUID,
+  incompleteMockAssignment,
   mockAssignment,
   mockAssignment2,
   mockResponses,
@@ -16,7 +17,10 @@ const mockAssignmentService: Partial<AssignmentService> = {
     return mockAssignment;
   },
   async getByUuid(): Promise<Assignment> {
-    return mockAssignment2;
+    return incompleteMockAssignment;
+  },
+  async start(): Promise<Assignment> {
+    return mockAssignment;
   },
 };
 
@@ -56,6 +60,16 @@ describe('AssignmentController', () => {
 
   it('should complete an assignment', async () => {
     const assignment = await controller.complete(assignment_UUID, mockCompleteAssignmentDto);
+    expect(assignment).toEqual(mockAssignment);
+  });
+
+  it('should mark an assignment as in progress', async () => {
+    const assignment = () => controller.start('bad!');
+    expect(assignment).rejects.toThrow();
+  });
+
+  it('should mark an assignment as in progress', async () => {
+    const assignment = await controller.start(assignment_UUID);
     expect(assignment).toEqual(mockAssignment);
   });
 });

--- a/src/assignment/assignment.controller.spec.ts
+++ b/src/assignment/assignment.controller.spec.ts
@@ -58,9 +58,8 @@ describe('AssignmentController', () => {
     expect(assignment).toEqual(mockAssignment);
   });
 
-  it('should mark an assignment as in progress', async () => {
-    const assignment = () => controller.start('bad!');
-    expect(assignment).rejects.toThrow();
+  it('should mark an assignment as in progress', () => {
+    expect(controller.start('bad!')).rejects.toThrow();
   });
 
   it('should mark an assignment as in progress', async () => {

--- a/src/assignment/assignment.controller.spec.ts
+++ b/src/assignment/assignment.controller.spec.ts
@@ -5,11 +5,13 @@ import { AssignmentController } from './assignment.controller';
 import { AssignmentService } from './assignment.service';
 import {
   assignment_UUID,
-  incompleteMockAssignment, inProgressMockAssignment,
+  incompleteMockAssignment,
+  inProgressMockAssignment,
   mockAssignment,
   mockResponses,
 } from './assignment.service.spec';
 import { Assignment } from './types/assignment.entity';
+import { AssignmentStatus } from './types/assignmentStatus';
 
 const mockAssignmentService: Partial<AssignmentService> = {
   async complete(): Promise<Assignment> {
@@ -69,6 +71,6 @@ describe('AssignmentController', () => {
 
   it('should mark an assignment as in progress', async () => {
     const assignment = await controller.start(assignment_UUID);
-    expect(assignment).toEqual(inProgressMockAssignment);
+    expect(assignment.status).toEqual(AssignmentStatus.IN_PROGRESS);
   });
 });

--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -1,4 +1,13 @@
-import { BadRequestException, Body, Controller, Param, ParseUUIDPipe, Post } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { AssignmentService } from './assignment.service';
 import { CompleteAssignmentDto } from './dto/complete-assignment.dto';
 import { Assignment } from './types/assignment.entity';
@@ -21,5 +30,13 @@ export class AssignmentController {
       throw new BadRequestException('This assignment does not exist.');
     }
     return this.assignmentService.complete(uuid, completeAssignmentDto.responses);
+  }
+
+  @Patch(':uuid')
+  start(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<Assignment> {
+    if (!this.assignmentService.getByUuid(uuid)) {
+      throw new BadRequestException('This assignment does not exist.');
+    }
+    return this.assignmentService.start(uuid);
   }
 }

--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -6,7 +6,6 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
-  Put,
 } from '@nestjs/common';
 import { AssignmentService } from './assignment.service';
 import { CompleteAssignmentDto } from './dto/complete-assignment.dto';
@@ -26,17 +25,26 @@ export class AssignmentController {
     @Param('uuid', ParseUUIDPipe) uuid: string,
     @Body() completeAssignmentDto: CompleteAssignmentDto,
   ): Promise<Assignment> {
+    await this.assertAssignmentWithUuidExists(uuid);
+    return await this.assignmentService.complete(uuid, completeAssignmentDto.responses);
+  }
+
+  /**
+   * Marks an assignment as started, the resulting assignment will change status to IN_PROGRESS.
+   */
+  @Patch(':uuid')
+  async start(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<Assignment> {
+    await this.assertAssignmentWithUuidExists(uuid);
+    return await this.assignmentService.start(uuid);
+  }
+
+  /**
+   * @param uuid UUID of the assignment
+   * @throws BadRequestException if the assignment does not exist
+   */
+  private async assertAssignmentWithUuidExists(uuid: string): Promise<void> {
     if (!(await this.assignmentService.getByUuid(uuid))) {
       throw new BadRequestException('This assignment does not exist.');
     }
-    return this.assignmentService.complete(uuid, completeAssignmentDto.responses);
-  }
-
-  @Patch(':uuid')
-  start(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<Assignment> {
-    if (!this.assignmentService.getByUuid(uuid)) {
-      throw new BadRequestException('This assignment does not exist.');
-    }
-    return this.assignmentService.start(uuid);
   }
 }

--- a/src/assignment/assignment.service.spec.ts
+++ b/src/assignment/assignment.service.spec.ts
@@ -19,6 +19,7 @@ import { Response } from '../response/types/response.entity';
 const reviewer_UUID = '123e4567-e89b-12d3-a456-426614174000';
 export const assignment_UUID = '123e4567-e89b-12d3-a456-426614174330';
 const assignment_UUID2 = '123e4567-e89b-12d3-a456-426614174330';
+const assignment_UUID3 = '79233fb0-9036-11ec-b909-0242ac120002';
 
 const mockReviewer: Reviewer = {
   ...reviewerExamples[0],
@@ -47,6 +48,16 @@ export const inProgressMockAssignment: Assignment = {
   id: 1,
   survey: mockSurvey,
   status: AssignmentStatus.IN_PROGRESS,
+  responses: [],
+};
+
+export const incompleteMockAssignment2: Assignment = {
+  uuid: assignment_UUID3,
+  reviewer: mockReviewer,
+  youth: mockYouth,
+  id: 1,
+  survey: mockSurvey,
+  status: AssignmentStatus.INCOMPLETE,
   responses: [],
 };
 
@@ -142,6 +153,7 @@ describe('AssignmentService', () => {
   });
 
   it('should complete an assignment', async () => {
+    jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(incompleteMockAssignment);
     const assignment = await service.complete(mockAssignment.uuid, mockResponses);
     expect(assignment).toEqual(mockAssignment);
   });
@@ -153,8 +165,10 @@ describe('AssignmentService', () => {
   });
 
   it('should start an assignment', async () => {
-    jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(incompleteMockAssignment);
-    const assignment = await service.start(assignment_UUID);
-    expect(assignment).toEqual(inProgressMockAssignment);
+    jest
+      .spyOn(mockAssignmentRepository, 'findOne')
+      .mockResolvedValueOnce(incompleteMockAssignment2);
+    const assignment = await service.start(assignment_UUID3);
+    expect(assignment.status).toEqual(AssignmentStatus.IN_PROGRESS);
   });
 });

--- a/src/assignment/assignment.service.spec.ts
+++ b/src/assignment/assignment.service.spec.ts
@@ -40,6 +40,16 @@ export const incompleteMockAssignment: Assignment = {
   responses: [],
 };
 
+export const inProgressMockAssignment: Assignment = {
+  uuid: assignment_UUID,
+  reviewer: mockReviewer,
+  youth: mockYouth,
+  id: 1,
+  survey: mockSurvey,
+  status: AssignmentStatus.IN_PROGRESS,
+  responses: [],
+};
+
 export const mockAssignment: Assignment = {
   uuid: assignment_UUID,
   reviewer: mockReviewer,
@@ -134,5 +144,17 @@ describe('AssignmentService', () => {
   it('should complete an assignment', async () => {
     const assignment = await service.complete(mockAssignment.uuid, mockResponses);
     expect(assignment).toEqual(mockAssignment);
+  });
+
+  it('should not start an assignment that is complete', async () => {
+    jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(mockAssignment);
+    const assignment = () => service.start(mockAssignment.uuid);
+    expect(assignment).rejects.toThrow();
+  });
+
+  it('should start an assignment', async () => {
+    jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(incompleteMockAssignment);
+    const assignment = await service.start(assignment_UUID);
+    expect(assignment).toEqual(inProgressMockAssignment);
   });
 });

--- a/src/assignment/assignment.service.spec.ts
+++ b/src/assignment/assignment.service.spec.ts
@@ -158,10 +158,9 @@ describe('AssignmentService', () => {
     expect(assignment).toEqual(mockAssignment);
   });
 
-  it('should not start an assignment that is complete', async () => {
+  it('should not start an assignment that is complete', () => {
     jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(mockAssignment);
-    const assignment = () => service.start(mockAssignment.uuid);
-    expect(assignment).rejects.toThrow();
+    expect(service.start(mockAssignment.uuid)).rejects.toThrow();
   });
 
   it('should start an assignment', async () => {

--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -67,7 +67,15 @@ export class AssignmentService {
     await this.responseRepository.save(responsesToSave);
     assignment = await this.getByUuid(uuid);
     assignment.status = AssignmentStatus.COMPLETED;
-    await this.assignmentRepository.save(assignment);
-    return await this.getByUuid(uuid);
+    return this.assignmentRepository.save(assignment);
+  }
+
+  async start(uuid: string): Promise<Assignment> {
+    const assignment = await this.getByUuid(uuid);
+    if (assignment.status === AssignmentStatus.COMPLETED) {
+      throw new BadRequestException('This assignment has already been completed');
+    }
+    assignment.status = AssignmentStatus.IN_PROGRESS;
+    return await this.assignmentRepository.save(assignment);
   }
 }

--- a/test/e2e/survey.e2e-spec.ts
+++ b/test/e2e/survey.e2e-spec.ts
@@ -15,7 +15,6 @@ import { Assignment } from '../../src/assignment/types/assignment.entity';
 import { Youth } from '../../src/youth/types/youth.entity';
 import { Reviewer } from '../../src/reviewer/types/reviewer.entity';
 import { CreateBatchAssignmentsDto } from '../../src/survey/dto/create-batch-assignments.dto';
-import { mockAssignment } from '../../src/assignment/assignment.service.spec';
 import { YouthRoles } from '../../src/youth/types/youthRoles';
 import { AssignmentStatus } from '../../src/assignment/types/assignmentStatus';
 


### PR DESCRIPTION
## Summary 
- When a reviewer starts an assignment, we need to record that they have started it in our database as this is a metric that JPAL requested. In order to do that we added PATCH /assignment/:uuid endpoint to set status of assignment to be in progress
- Reorganized mock data in assignment service spec
- Small package.json script change to make jest work with M1 