### PR TITLE
Send emails with survey link on patch survey

### DIFF
--- a/example.env
+++ b/example.env
@@ -18,4 +18,4 @@ PACT_BROKER_URL=https://c4cneu.pactflow.io
 
 PORT=xxxx
 
-# PROD_URL=http://localhost:5000
+# PROD_URL=http://localhost:3000

--- a/example.env
+++ b/example.env
@@ -17,3 +17,5 @@ PACT_BROKER_TOKEN=xxx
 PACT_BROKER_URL=https://c4cneu.pactflow.io
 
 PORT=xxxx
+
+# PROD_URL=http://localhost:5000

--- a/src/survey/survey.controller.ts
+++ b/src/survey/survey.controller.ts
@@ -35,6 +35,7 @@ export class SurveyController {
     @Body() createBatchAssignmentsDto: CreateBatchAssignmentsDto,
   ): Promise<void> {
     await this.surveyService.createBatchAssignments(createBatchAssignmentsDto);
+    await this.surveyService.sendEmailToReviewersInBatchAssignment(createBatchAssignmentsDto);
   }
 
   @Get(':surveyUuid/:reviewerUuid')

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -8,8 +8,8 @@ import { Assignment } from '../assignment/types/assignment.entity';
 import { Youth } from '../youth/types/youth.entity';
 import { Reviewer } from '../reviewer/types/reviewer.entity';
 import { EmailService } from '../util/email/email.service';
-import { AmazonSESWrapper } from 'src/util/email/amazon-ses.wrapper';
-import { amazonSESClientFactory } from 'src/util/email/amazon-ses-client.factory';
+import { AmazonSESWrapper } from '../util/email/amazon-ses.wrapper';
+import { amazonSESClientFactory } from '../util/email/amazon-ses-client.factory';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Survey, SurveyTemplate, Assignment, Youth, Reviewer])],

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -7,7 +7,7 @@ import { SurveyTemplate } from '../surveyTemplate/types/surveyTemplate.entity';
 import { Assignment } from '../assignment/types/assignment.entity';
 import { Youth } from '../youth/types/youth.entity';
 import { Reviewer } from '../reviewer/types/reviewer.entity';
-import { EmailService } from 'src/util/email/email.service';
+import { EmailService } from '../util/email/email.service';
 import { AmazonSESWrapper } from 'src/util/email/amazon-ses.wrapper';
 import { amazonSESClientFactory } from 'src/util/email/amazon-ses-client.factory';
 

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -7,10 +7,13 @@ import { SurveyTemplate } from '../surveyTemplate/types/surveyTemplate.entity';
 import { Assignment } from '../assignment/types/assignment.entity';
 import { Youth } from '../youth/types/youth.entity';
 import { Reviewer } from '../reviewer/types/reviewer.entity';
+import { EmailService } from 'src/util/email/email.service';
+import { AmazonSESWrapper } from 'src/util/email/amazon-ses.wrapper';
+import { amazonSESClientFactory } from 'src/util/email/amazon-ses-client.factory';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Survey, SurveyTemplate, Assignment, Youth, Reviewer])],
-  providers: [SurveyService],
+  providers: [SurveyService, EmailService, AmazonSESWrapper, amazonSESClientFactory],
   controllers: [SurveyController],
 })
 export class SurveyModule {}

--- a/src/survey/survey.service.spec.ts
+++ b/src/survey/survey.service.spec.ts
@@ -45,7 +45,7 @@ export const mockSurveyTemplateRepository: Partial<Repository<SurveyTemplate>> =
 };
 
 const mockEmailService: Partial<EmailService> = {
-  queueEmail: jest.fn(async (i, j, k) => Promise.resolve())
+  queueEmail: jest.fn(),
 };
 
 describe('SurveyService', () => {
@@ -157,14 +157,14 @@ describe('SurveyService', () => {
       email: 'alpha@sgmail.com',
       firstName: 'Alpha',
       lastName: 'Beta',
-    }
+    };
     const reviewer2 = {
-      id: 2, 
+      id: 2,
       uuid: 'test2',
       email: 'epsilon@sgmail.com',
       firstName: 'Epsilon',
       lastName: 'Omega',
-    }
+    };
 
     mockReviewerRepository.save(reviewer1);
     mockReviewerRepository.save(reviewer2);
@@ -204,7 +204,17 @@ describe('SurveyService', () => {
     await service.sendEmailToReviewersInBatchAssignment(dto);
 
     expect(mockEmailService.queueEmail).toHaveBeenCalledTimes(2);
-    expect(mockEmailService.queueEmail).toHaveBeenNthCalledWith(1, reviewer1.email, service.emailSubject(reviewer1.firstName, reviewer1.lastName), service.generateEmailBodyHTML(surveyUUID, reviewer1.uuid))
-    expect(mockEmailService.queueEmail).toHaveBeenNthCalledWith(2, reviewer2.email, service.emailSubject(reviewer2.firstName, reviewer2.lastName), service.generateEmailBodyHTML(surveyUUID, reviewer2.uuid))
+    expect(mockEmailService.queueEmail).toHaveBeenNthCalledWith(
+      1,
+      reviewer1.email,
+      service.emailSubject(reviewer1.firstName, reviewer1.lastName),
+      service.generateEmailBodyHTML(surveyUUID, reviewer1.uuid),
+    );
+    expect(mockEmailService.queueEmail).toHaveBeenNthCalledWith(
+      2,
+      reviewer2.email,
+      service.emailSubject(reviewer2.firstName, reviewer2.lastName),
+      service.generateEmailBodyHTML(surveyUUID, reviewer2.uuid),
+    );
   });
 });

--- a/src/survey/survey.service.spec.ts
+++ b/src/survey/survey.service.spec.ts
@@ -181,9 +181,10 @@ describe('SurveyService', () => {
       ],
     };
 
+    await service.createBatchAssignments(dto);
     await service.sendEmailToReviewersInBatchAssignment(dto);
 
-    // expect emailservice.queueEmail to have been called twice, once with first pair, once with second pair
-    // expect(mockEmailService.queueEmail).toHaveBeenCalledTimes(2);
+    expect(mockEmailService.queueEmail).toHaveBeenCalledTimes(2);
+    // expect(mockEmailService.queueEmail).toHaveBeenCalledWith('alpha@sgmail.com', service.emailSubject('Alpha', 'Beta'));
   });
 });

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -103,10 +103,15 @@ export class SurveyService {
         try {
           // queue the email to be sent to the reviewer with the link to /survey/:survey_id/:reviewer_id
           const reviewerInfo = pair.reviewer;
-          const reviewer: Reviewer = await this.reviewerRepository.findOneOrFail({
+          const reviewer: Reviewer = await this.reviewerRepository.findOne({
             firstName: reviewerInfo.firstName,
             lastName: reviewerInfo.lastName,
           });
+          if (!reviewer) {
+            throw new BadRequestException(
+              `Requested reviewer (${reviewerInfo.firstName} ${reviewerInfo.lastName}) does not exist`,
+            );
+          }
           const subject: string = this.emailSubject(reviewer.firstName, reviewer.lastName);
           const emailBodyHTML: string = this.generateEmailBodyHTML(dto.surveyUUID, reviewer.uuid);
 

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -113,8 +113,8 @@ export class SurveyService {
    * @returns the email body HTML with a link to /survey/{surveyUUID}/{reviewerUUID}
    */
   generateEmailBodyHTML(surveyUUID: string, reviewerUUID: string): string {
-    // TODO: what is the actual link that we should be using?
-    const link: string = `http://localhost:5000/survey/${surveyUUID}/${reviewerUUID}`;
+    const domain: string = process.env.PROD_URL || 'http://localhost:5000' 
+    const link: string = `${domain}/survey/${surveyUUID}/${reviewerUUID}`;
     return `
       <html>
         <body>


### PR DESCRIPTION
### ℹ️ Issue

Closes [clickup ticket link](https://app.clickup.com/t/1hh69ca)

### 📝 Description

- Added SurveyService.sendEmailToReviewersInBatchAssignment method which uses the EmailService to send emails containing the survey links to each of the reviewers in a batch assignment
- Added helper methods for the above method
- Added controller logic to call the above method on a PATCH request to /survey after calling SurveyService.createBatchAssignments

### ✔️ Verification

I used Postman to create a PATCH request to /survey with two pairs (of youth and reviewer). I verified that the assignment was created in the DB and that both reviewer accounts received emails.

Unit test in survey.service.spec.ts which verifies that the EmailService's queueEmail method is called with the correct arguments for a sample input.

![image](https://user-images.githubusercontent.com/16907452/161608193-6615ea1b-6ccc-4849-a81f-bf4c92087088.png)

### 🏕️ (Optional) Future Work / Notes

The SurveyService.createBatchAssignments method errors when given youths or reviewers that already exist. Is that intentional? (It's because of a constraint on the youth and reviewer tables in the DB and the fact that the method saves each of the youths and reviewers in the createBatchAssignmentsDto)
