### PR TITLE
Add secondary email/phone fields and PATCH endpoint

### DIFF
--- a/migrations/1666303669991-add-reminder-send.ts
+++ b/migrations/1666303669991-add-reminder-send.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addReminderSend1666303669991 implements MigrationInterface {
+  name = 'addReminderSend1666303669991';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ADD "reminderSent" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "assignment" DROP COLUMN "reminderSent"`);
+  }
+}

--- a/migrations/1666305971601-add-start-time-to-assignment.ts
+++ b/migrations/1666305971601-add-start-time-to-assignment.ts
@@ -1,14 +1,15 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class addStartTimeToAssignment1666305971601 implements MigrationInterface {
-    name = 'addStartTimeToAssignment1666305971601'
+  name = 'addStartTimeToAssignment1666305971601';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "assignment" ADD "started" TIMESTAMP NOT NULL DEFAULT now()`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "assignment" ADD "started" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "assignment" DROP COLUMN "started"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "assignment" DROP COLUMN "started"`);
+  }
 }

--- a/migrations/1666305971601-add-start-time-to-assignment.ts
+++ b/migrations/1666305971601-add-start-time-to-assignment.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addStartTimeToAssignment1666305971601 implements MigrationInterface {
+    name = 'addStartTimeToAssignment1666305971601'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "assignment" ADD "started" TIMESTAMP NOT NULL DEFAULT now()`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "assignment" DROP COLUMN "started"`);
+    }
+
+}

--- a/migrations/1668052469602-add-email-phone-to-reviewer.ts
+++ b/migrations/1668052469602-add-email-phone-to-reviewer.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addEmailPhoneToReviewer1668052469602 implements MigrationInterface {
+  name = 'addEmailPhoneToReviewer1668052469602';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "reviewer" ADD "secondaryEmail" character varying`);
+    await queryRunner.query(`ALTER TABLE "reviewer" ADD "phone" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "reviewer" DROP COLUMN "phone"`);
+    await queryRunner.query(`ALTER TABLE "reviewer" DROP COLUMN "secondaryEmail"`);
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { UtilModule } from './util/util.module';
 import { SurveyModule } from './survey/survey.module';
 import { AssignmentModule } from './assignment/assignment.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ReviewerModule } from './reviewer/reviewer.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     HealthModule,
     SurveyModule,
     AssignmentModule,
+    ReviewerModule,
     ScheduleModule.forRoot(),
   ],
   controllers: [AppController, UserController],

--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -172,4 +172,45 @@ export class AssignmentService {
       ),
     );
   }
+
+  reviewerEmailSubject(youthFirstName: string, youthLastName: string) {
+    return `<p>Reminder: Incomplete survey for ${youthFirstName} ${youthLastName}.</p>`;
+  }
+
+  reviewerEmailHTML(youthFirstName: string, youthLastName: string) {
+    return `<p>You have an unfinished survey for ${youthFirstName} ${youthLastName}. Please complete it soon.</p>`;
+  }
+
+  async sendToReviewer(assignment: Assignment): Promise<void> {
+    try {
+      await this.emailService.queueEmail(
+        assignment.reviewer.email,
+        this.reviewerEmailSubject(assignment.youth.firstName, assignment.youth.lastName),
+        this.reviewerEmailHTML(assignment.youth.firstName, assignment.youth.lastName),
+      );
+    } catch (e) {
+      this.logger.error(e);
+    }
+  }
+
+  @Cron('0 17 * * *')
+  async sendRemindersToReviewers(): Promise<void> {
+    const unfinishedAssignments = await this.assignmentRepository.find({
+      relations: ['reviewer', 'survey', 'youth'],
+      where: {
+        or: [{ status: AssignmentStatus.IN_PROGRESS }, { status: AssignmentStatus.INCOMPLETE }],
+      },
+    });
+    await Promise.all(
+      unfinishedAssignments.map(async (assignment) => {
+        const lastWeek = new Date();
+        lastWeek.setDate(lastWeek.getDate() - 7);
+        lastWeek.setHours(0, 0, 0, 0);
+
+        if (assignment.survey.date <= lastWeek) {
+          this.sendToReviewer(assignment);
+        }
+      }),
+    );
+  }
 }

--- a/src/assignment/types/assignment.entity.ts
+++ b/src/assignment/types/assignment.entity.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, Generated, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Generated,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Reviewer } from '../../reviewer/types/reviewer.entity';
 import { Youth } from '../../youth/types/youth.entity';
 import { Response } from '../../response/types/response.entity';
@@ -37,4 +45,10 @@ export class Assignment {
     cascade: true,
   })
   responses: Response[];
+
+  @Column({ default: false })
+  reminderSent: boolean;
+
+  @CreateDateColumn()
+  started: Date;
 }

--- a/src/reviewer/dto/update-reviewer-dto.ts
+++ b/src/reviewer/dto/update-reviewer-dto.ts
@@ -1,0 +1,4 @@
+export interface UpdateReviewerDto {
+  secondaryEmail?: string;
+  phone?: string;
+}

--- a/src/reviewer/reviewer.controller.spec.ts
+++ b/src/reviewer/reviewer.controller.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReviewerController } from './reviewer.controller';
+import { ReviewerService } from './reviewer.service';
+import { reviewerExamples } from './reviewer.examples';
+import { Reviewer } from './types/reviewer.entity';
+import { UpdateReviewerDto } from './dto/update-reviewer-dto';
+
+const mockReviewer: Reviewer = {
+  ...reviewerExamples[0],
+  uuid: '00000000-0000-0000-0000-000000000000',
+  id: 1,
+};
+
+const mockReviewerService: Partial<ReviewerService> = {
+  async getByUuid(uuid: string): Promise<Reviewer> {
+    return mockReviewer;
+  },
+
+  async updateReviewer(uuid: string, newData: UpdateReviewerDto): Promise<Reviewer> {
+    const reviewer = await this.getByUuid(uuid);
+    reviewer.secondaryEmail = newData.secondaryEmail;
+    reviewer.phone = newData.phone;
+    return reviewer;
+  },
+};
+
+const mockUpdateReviewerDto: UpdateReviewerDto = {
+  secondaryEmail: 'newEmail@test.com',
+  phone: '555-555-5555',
+};
+
+describe('ReviewerController', () => {
+  let controller: ReviewerController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReviewerController],
+      providers: [
+        {
+          provide: ReviewerService,
+          useValue: mockReviewerService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ReviewerController>(ReviewerController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should fail to update a reviewer that does not exist', async () => {
+    jest.spyOn(mockReviewerService, 'getByUuid').mockResolvedValueOnce(undefined);
+    await expect(controller.updateReviewer('bad-uuid', mockUpdateReviewerDto)).rejects.toThrow(
+      'This reviewer does not exist.',
+    );
+  });
+
+  it('should update a reviewer', async () => {
+    const reviewer = await controller.updateReviewer(
+      '00000000-0000-0000-0000-000000000000',
+      mockUpdateReviewerDto,
+    );
+    expect(reviewer.secondaryEmail).toEqual(mockUpdateReviewerDto.secondaryEmail);
+    expect(reviewer.phone).toEqual(mockUpdateReviewerDto.phone);
+  });
+});

--- a/src/reviewer/reviewer.controller.ts
+++ b/src/reviewer/reviewer.controller.ts
@@ -1,0 +1,33 @@
+import { BadRequestException, Body, Controller, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
+import { UpdateReviewerDto } from './dto/update-reviewer-dto';
+import { ReviewerService } from './reviewer.service';
+import { Reviewer } from './types/reviewer.entity';
+
+@Controller('reviewer')
+export class ReviewerController {
+  constructor(private reviewerService: ReviewerService) {}
+
+  /**
+   * @param uuid UUID of the reviewer
+   * @throws BadRequestException if the assignment does not exist
+   */
+  private async assertReviewerWithUuidExists(uuid: string): Promise<void> {
+    if (!(await this.reviewerService.getByUuid(uuid))) {
+      throw new BadRequestException('This reviewer does not exist.');
+    }
+  }
+
+  /**
+   * Update a reviewer's email and/or phone number.
+   * @param uuid UUID of the reviewer
+   * @throws BadRequestException if the reviewer does not exist
+   */
+  @Patch(':uuid')
+  async updateReviewer(
+    @Param('uuid', ParseUUIDPipe) uuid: string,
+    @Body() updateReviewerDto: UpdateReviewerDto,
+  ): Promise<Reviewer> {
+    await this.assertReviewerWithUuidExists(uuid);
+    return await this.reviewerService.updateReviewer(uuid, updateReviewerDto);
+  }
+}

--- a/src/reviewer/reviewer.module.ts
+++ b/src/reviewer/reviewer.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReviewerController } from './reviewer.controller';
+import { ReviewerService } from './reviewer.service';
+import { Reviewer } from './types/reviewer.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Reviewer])],
+  providers: [ReviewerService],
+  controllers: [ReviewerController],
+})
+export class ReviewerModule {}

--- a/src/reviewer/reviewer.service.spec.ts
+++ b/src/reviewer/reviewer.service.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { reviewerExamples } from './reviewer.examples';
+import { ReviewerService } from './reviewer.service';
+import { Reviewer } from './types/reviewer.entity';
+
+const mockReviewer: Reviewer = {
+  ...reviewerExamples[0],
+  uuid: '00000000-0000-0000-0000-000000000000',
+  id: 1,
+};
+
+export const mockReviewerRepository: Partial<Repository<Reviewer>> = {
+  async findOne() {
+    return mockReviewer;
+  },
+
+  save<T>(reviewer): T {
+    return reviewer;
+  },
+};
+
+describe('ReviewerService', () => {
+  let service: ReviewerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReviewerService,
+        { provide: getRepositoryToken(Reviewer), useValue: mockReviewerRepository },
+      ],
+    }).compile();
+
+    service = module.get<ReviewerService>(ReviewerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return a reviewer', async () => {
+    jest.spyOn(mockReviewerRepository, 'findOne').mockResolvedValueOnce(mockReviewer);
+
+    const result = await service.getByUuid('00000000-0000-0000-0000-000000000000');
+    expect(result).toEqual(mockReviewer);
+  });
+
+  it('should update a reviewer', async () => {
+    jest.spyOn(mockReviewerRepository, 'findOne').mockResolvedValueOnce(mockReviewer);
+
+    const result = await service.updateReviewer('00000000-0000-0000-0000-000000000000', {
+      secondaryEmail: 'newEmail@test.com',
+      phone: '555-555-5555',
+    });
+    expect(result).toEqual({
+      ...mockReviewer,
+      secondaryEmail: 'newEmail@test.com',
+      phone: '555-555-5555',
+    });
+  });
+});

--- a/src/reviewer/reviewer.service.ts
+++ b/src/reviewer/reviewer.service.ts
@@ -1,0 +1,45 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UpdateReviewerDto } from './dto/update-reviewer-dto';
+import { Reviewer } from './types/reviewer.entity';
+
+@Injectable()
+export class ReviewerService {
+  private logger = new Logger(ReviewerService.name);
+
+  constructor(
+    @InjectRepository(Reviewer)
+    private reviewerRepository: Repository<Reviewer>,
+  ) {}
+
+  async getByUuid(uuid: string): Promise<Reviewer> {
+    return await this.reviewerRepository.findOne({
+      relations: [],
+      where: { uuid },
+    });
+  }
+
+  async updateReviewer(uuid: string, newData: UpdateReviewerDto): Promise<Reviewer> {
+    try {
+      const reviewer = await this.getByUuid(uuid);
+
+      if (!reviewer) {
+        throw new BadRequestException('Reviewer not found.');
+      }
+
+      if (newData.secondaryEmail) {
+        reviewer.secondaryEmail = newData.secondaryEmail;
+      }
+
+      if (newData.phone) {
+        reviewer.phone = newData.phone;
+      }
+
+      await this.reviewerRepository.save(reviewer);
+      return reviewer;
+    } catch (e) {
+      this.logger.error(e);
+    }
+  }
+}

--- a/src/reviewer/types/reviewer.entity.ts
+++ b/src/reviewer/types/reviewer.entity.ts
@@ -21,4 +21,14 @@ export class Reviewer {
 
   @Column()
   lastName: string;
+
+  @Column({
+    default: null,
+  })
+  secondaryEmail?: string;
+
+  @Column({
+    default: null,
+  })
+  phone?: string;
 }

--- a/test/e2e/assignment.e2e-spec.ts
+++ b/test/e2e/assignment.e2e-spec.ts
@@ -85,6 +85,7 @@ describe('Assignment e2e', () => {
       youth: youthExamples[0],
       reviewer: reviewerExamples[0],
       responses: [],
+      started: new Date('2020-01-01'),
     });
   });
 
@@ -122,6 +123,8 @@ describe('Assignment e2e', () => {
         },
       ],
       sent: false,
+      reminderSent: false,
+      started: new Date('2020-01-01').toISOString(),
       // hacky sure, but we dont care about these anyway
       reviewer: null,
       youth: null,


### PR DESCRIPTION
### ℹ️ Issue

Closes [clickup ticket link](https://app.clickup.com/t/3yp4wxf)

### 📝 Description

Briefly list the changes made to the code:

- Added `secondaryEmail` and `phone` fields (both defaulting to `null` to the database for the `Reviewer` table
- Added a PATCH endpoint at `/reviewer/:uuid` to update these two fields
- Created new files for reviewers: `reviewer.service.ts`, `reviewer.controller.ts`, `reviewer.module.ts`, `reviewer.service.spec.ts`, `reviewer.controller.spec.ts`

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. 

- Added unit tests for the new reviewer service and controller
- Manually verified PATCH endpoint functionality with Postman