### PR TITLE
New route: Get survey assignments

### DIFF
--- a/src/survey/survey.controller.spec.ts
+++ b/src/survey/survey.controller.spec.ts
@@ -100,4 +100,8 @@ describe('SurveyController', () => {
     expect(await controller.findAllSurveys(mockResearcher)).toEqual(listMockSurveys);
     expect(mockSurveyService.getAllSurveys).toHaveBeenCalled();
   });
+
+  describe('getSurveyAssignments', () => {
+    
+  });
 });

--- a/src/survey/survey.controller.spec.ts
+++ b/src/survey/survey.controller.spec.ts
@@ -54,6 +54,7 @@ export const mockSurveyService: Partial<SurveyService> = {
 
   findAllSurveysByUser: jest.fn(() => Promise.resolve([mockSurvey])),
   getAllSurveys: jest.fn(() => Promise.resolve(listMockSurveys)),
+  getSurveyAssignments: jest.fn(() => Promise.resolve(mockSurvey)),
 };
 
 describe('SurveyController', () => {
@@ -102,6 +103,9 @@ describe('SurveyController', () => {
   });
 
   describe('getSurveyAssignments', () => {
-    
+    it('should get the requested survey', async () => {
+      expect(await controller.getSurveyAssignments(UUID, mockUser)).toEqual(mockSurvey);
+      expect(mockSurveyService.getSurveyAssignments).toHaveBeenCalledWith(UUID, mockUser);
+    });
   });
 });

--- a/src/survey/survey.controller.ts
+++ b/src/survey/survey.controller.ts
@@ -41,7 +41,7 @@ export class SurveyController {
   @Get(':uuid/assignments')
   @Auth(Role.ADMIN, Role.RESEARCHER)
   async getSurveyAssignments(@Param('uuid', ParseUUIDPipe) uuid: string, @ReqUser() user: User) {
-    return this.surveyService.getSurveyAssignments(uuid, user)
+    return this.surveyService.getSurveyAssignments(uuid, user);
   }
 
   @Get(':surveyUuid/:reviewerUuid')

--- a/src/survey/survey.controller.ts
+++ b/src/survey/survey.controller.ts
@@ -38,6 +38,12 @@ export class SurveyController {
     await this.surveyService.sendEmailToReviewersInBatchAssignment(createBatchAssignmentsDto);
   }
 
+  @Get(':uuid/assignments')
+  @Auth(Role.ADMIN, Role.RESEARCHER)
+  async getSurveyAssignments(@Param('uuid', ParseUUIDPipe) uuid: string, @ReqUser() user: User) {
+    return this.surveyService.getSurveyAssignments(uuid, user)
+  }
+
   @Get(':surveyUuid/:reviewerUuid')
   async getReviewerSurvey(
     @Param('surveyUuid', ParseUUIDPipe) surveyUuid: string,

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, Logger, Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Logger,
+  Injectable,
+  UnauthorizedException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Survey } from './types/survey.entity';
@@ -15,7 +21,7 @@ import { SurveyData } from './dto/survey-assignment.dto';
 import { Youth as SurveyDataYouth } from './dto/survey-assignment.dto';
 import { Question as SurveyDataQuestion } from './dto/survey-assignment.dto';
 import { EmailService } from '../util/email/email.service';
-import { Role } from '../user/types/role'
+import { Role } from '../user/types/role';
 
 @Injectable()
 export class SurveyService {
@@ -251,7 +257,7 @@ export class SurveyService {
     });
 
     if (survey === undefined) {
-      throw new BadRequestException(`Requested survey does not exist`);
+      throw new NotFoundException(`Requested survey does not exist`);
     }
 
     if (user.role === Role.ADMIN && survey.creator.id !== user.id) {


### PR DESCRIPTION
### ℹ️ Issue

Closes #88 

### 📝 Description
- Added route at `GET /survey/:uuid/assignments` + service method to fetch survey assignments
  - also gets assigned reviewer and youth

### ✔️ Verification

- Tested route w/ postman:
  - Verified route retrieves above information for a survey
  - Verified a researcher can get assignments for any survey
  - Verified an admin can only get assignments for surveys they created (returns 401 otherwise)
- Automated tests for above behaviors

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
