### PR TITLE
Add route: get assignment responses

### DIFF
--- a/src/assignment/assignment.controller.spec.ts
+++ b/src/assignment/assignment.controller.spec.ts
@@ -101,14 +101,16 @@ describe('AssignmentController', () => {
       const assignment = await controller.viewResponse('123-456', { id: 2, role: Role.RESEARCHER });
 
       expect(assignment).toEqual(mockAssignmentResponses);
-    })
+    });
 
     it('should throw bad request exception when no assignment is found', async () => {
       expect.assertions(1);
 
       mockAssignmentService.getByUuid.mockResolvedValue(undefined);
-      
-      await expect(controller.viewResponse('xxx-xxx', { id: 1 })).rejects.toThrow(BadRequestException);
+
+      await expect(controller.viewResponse('xxx-xxx', { id: 1 })).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
     it('should return unauthorized exception if assignment creator is not the requester and requeseter is admin', async () => {
@@ -116,7 +118,9 @@ describe('AssignmentController', () => {
 
       mockAssignmentService.getByUuid.mockResolvedValue(mockAssignmentResponses);
 
-      await expect(controller.viewResponse('xxx-xxx', { id: 2, role: Role.ADMIN })).rejects.toThrow(UnauthorizedException);
+      await expect(controller.viewResponse('xxx-xxx', { id: 2, role: Role.ADMIN })).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
-  })
+  });
 });

--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -21,12 +21,22 @@ import { ReqUser } from '../auth/decorators/user.decorator';
 export class AssignmentController {
   constructor(private assignmentService: AssignmentService) {}
 
-  
   @Get(':uuid/responses')
   @Auth(Role.RESEARCHER, Role.ADMIN)
-  async viewResponse(@Param('uuid', ParseUUIDPipe) uuid: string, @ReqUser() reqUser): Promise<Assignment> {
-    const assignment = await this.assignmentService.getByUuid(uuid, ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer', 'survey', 'survey.creator']);
-    
+  async viewResponse(
+    @Param('uuid', ParseUUIDPipe) uuid: string,
+    @ReqUser() reqUser,
+  ): Promise<Assignment> {
+    const assignment = await this.assignmentService.getByUuid(uuid, [
+      'responses',
+      'responses.question',
+      'responses.option',
+      'youth',
+      'reviewer',
+      'survey',
+      'survey.creator',
+    ]);
+
     if (!assignment) {
       throw new BadRequestException('This assignment does not exist.');
     }

--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -25,13 +25,12 @@ export class AssignmentController {
   @Get(':uuid/responses')
   @Auth(Role.RESEARCHER, Role.ADMIN)
   async viewResponse(@Param('uuid', ParseUUIDPipe) uuid: string, @ReqUser() reqUser): Promise<Assignment> {
-    // console.log(reqUser);
     const assignment = await this.assignmentService.getByUuid(uuid, ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer', 'survey', 'survey.creator']);
     
     if (!assignment) {
       throw new BadRequestException('This assignment does not exist.');
     }
-    if (assignment.survey.creator.id !== reqUser.id) {
+    if (reqUser.role === Role.ADMIN && assignment.survey.creator.id !== reqUser.id) {
       throw new UnauthorizedException('Admins can only view responses for surveys they created');
     }
 

--- a/src/assignment/assignment.service.spec.ts
+++ b/src/assignment/assignment.service.spec.ts
@@ -222,10 +222,10 @@ describe('AssignmentService', () => {
       expect(assignment).toEqual(mockAssignment2);
       expect(mockAssignmentRepository.findOne).toHaveBeenCalledWith({
         relations: ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer'],
-        where: { uuid: assignment_UUID2 }
+        where: { uuid: assignment_UUID2 },
       });
     });
-  
+
     it('should get an assignment using the given relations', async () => {
       jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(mockAssignment2);
 
@@ -234,10 +234,10 @@ describe('AssignmentService', () => {
       expect(assignment).toEqual(mockAssignment2);
       expect(mockAssignmentRepository.findOne).toHaveBeenCalledWith({
         relations: ['responses'],
-        where: { uuid: assignment_UUID2 }
+        where: { uuid: assignment_UUID2 },
       });
-    })
-  })
+    });
+  });
 
   it('should complete an assignment', async () => {
     jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(incompleteMockAssignment);

--- a/src/assignment/assignment.service.spec.ts
+++ b/src/assignment/assignment.service.spec.ts
@@ -213,11 +213,31 @@ describe('AssignmentService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should get an assignment by uuid', async () => {
-    jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(mockAssignment2);
-    const assignment = await service.getByUuid(assignment_UUID2);
-    expect(assignment).toEqual(mockAssignment2);
-  });
+  describe('getByUUID', () => {
+    it('should get an assignment by uuid with the default relations', async () => {
+      jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(mockAssignment2);
+
+      const assignment = await service.getByUuid(assignment_UUID2);
+
+      expect(assignment).toEqual(mockAssignment2);
+      expect(mockAssignmentRepository.findOne).toHaveBeenCalledWith({
+        relations: ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer'],
+        where: { uuid: assignment_UUID2 }
+      });
+    });
+  
+    it('should get an assignment using the given relations', async () => {
+      jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(mockAssignment2);
+
+      const assignment = await service.getByUuid(assignment_UUID2, ['responses']);
+
+      expect(assignment).toEqual(mockAssignment2);
+      expect(mockAssignmentRepository.findOne).toHaveBeenCalledWith({
+        relations: ['responses'],
+        where: { uuid: assignment_UUID2 }
+      });
+    })
+  })
 
   it('should complete an assignment', async () => {
     jest.spyOn(mockAssignmentRepository, 'findOne').mockResolvedValueOnce(incompleteMockAssignment);

--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -37,7 +37,16 @@ export class AssignmentService {
     private emailService: EmailService,
   ) {}
 
-  async getByUuid(uuid: string, relations: string[] = ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer']): Promise<Assignment> {
+  async getByUuid(
+    uuid: string,
+    relations: string[] = [
+      'responses',
+      'responses.question',
+      'responses.option',
+      'youth',
+      'reviewer',
+    ],
+  ): Promise<Assignment> {
     return await this.assignmentRepository.findOne({
       relations,
       where: { uuid },

--- a/src/assignment/assignment.service.ts
+++ b/src/assignment/assignment.service.ts
@@ -37,9 +37,9 @@ export class AssignmentService {
     private emailService: EmailService,
   ) {}
 
-  async getByUuid(uuid: string): Promise<Assignment> {
+  async getByUuid(uuid: string, relations: string[] = ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer']): Promise<Assignment> {
     return await this.assignmentRepository.findOne({
-      relations: ['responses', 'responses.question', 'responses.option', 'youth', 'reviewer'],
+      relations,
       where: { uuid },
     });
   }

--- a/src/auth/decorators/user.decorator.ts
+++ b/src/auth/decorators/user.decorator.ts
@@ -1,10 +1,11 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { DefinitelyAuthorizedRequest } from '../types/authorized-request';
+import { User } from 'src/user/types/user.entity';
 
 /**
  * Pulls the user object from the request, assuming that it exists.
  */
-export const ReqUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+export const ReqUser = createParamDecorator((data: unknown, ctx: ExecutionContext): User => {
   const request = ctx.switchToHttp().getRequest() as DefinitelyAuthorizedRequest;
   return request.user;
 });


### PR DESCRIPTION
### ℹ️ Issue

Closes #89 

### 📝 Description

- Added new route to get survey assignment responses
- Updated `getByUUID` in `assignment.service` to take relations to fetch for an assignment

### ✔️ Verification

- Verified researcher can access responses for any survey assignment
- Verified admins can only access responses for surveys they created

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
