### PR TITLE
random group assignment

### DIFF
--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -83,7 +83,17 @@ export class SurveyService {
     const survey = await this.getByUUID(dto.surveyUUID);
     const reviewers = dto.pairs.map((p) => p.reviewer);
     const reviewerEmails = reviewers.map((r) => r.email);
-    const youth = dto.pairs.map((p) => p.youth);
+    const treatmentPercentageFraction = survey.treatmentPercentage / 100;
+
+    const youth = dto.pairs.map((p) => {
+      /**
+       * Randomly assign youth to a group weighted by the survey's treatment percentage
+       * This may not be the 100% best way, but I think we can keep it simple for now
+       */
+      const youthRole =
+        Math.random() < treatmentPercentageFraction ? YouthRoles.TREATMENT : YouthRoles.CONTROL;
+      return { ...p.youth, role: youthRole };
+    });
     const youthEmails = youth.map((y) => y.email);
 
     // If we're given any existing reviewer-youth pairs for this survey, treat it as an invalid request and require the caller to remove them


### PR DESCRIPTION
### ℹ️ Issue

Closes x

### 📝 Description

- When creating assignments in `createBatchAssignments`, randomly assign youth to a group based on stored survey treatment percentage

### ✔️ Verification

- Manually verified that youth are created in groups + unit test for functionality

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
