### PR TITLE
Changed create batch assignment to not use index positions

### DIFF
--- a/src/survey/survey.service.spec.ts
+++ b/src/survey/survey.service.spec.ts
@@ -187,12 +187,18 @@ describe('SurveyService', () => {
 
       const youthCreateQB = jest.spyOn(mockYouthRepository, 'createQueryBuilder');
       const reviewerCreateQB = jest.spyOn(mockReviewerRepository, 'createQueryBuilder');
+      // const youthFind = jest
+      //   .spyOn(mockYouthRepository, 'find')
+      //   .mockReturnValueOnce([dto.pairs[0].youth]);
+      // const reviewerFind = jest
+      //   .spyOn(mockReviewerRepository, 'find')
+      //   .mockReturnValueOnce([dto.pairs[0].reviewer]);
       const youthFind = jest
         .spyOn(mockYouthRepository, 'find')
-        .mockReturnValueOnce([dto.pairs[0].youth]);
+        .mockResolvedValueOnce([dto.pairs[0].youth]);
       const reviewerFind = jest
         .spyOn(mockReviewerRepository, 'find')
-        .mockReturnValueOnce([dto.pairs[0].reviewer]);
+        .mockResolvedValueOnce([dto.pairs[0].reviewer]);
 
       await service.createBatchAssignments(dto);
       expect(youthCreateQB).toHaveBeenCalled();
@@ -244,8 +250,10 @@ describe('SurveyService', () => {
       youth2['role'] = YouthRoles.CONTROL;
 
       const assignmentSave = jest.spyOn(mockAssignmentRepository, 'save');
+      // jest.spyOn(mockYouthRepository, 'find').mockResolvedValueOnce([youth1, youth2]);
+      // jest.spyOn(mockReviewerRepository, 'find').mockResolvedValueOnce([reviewer, reviewer]);
       jest.spyOn(mockYouthRepository, 'find').mockResolvedValueOnce([youth1, youth2]);
-      jest.spyOn(mockReviewerRepository, 'find').mockResolvedValueOnce([reviewer, reviewer]);
+      jest.spyOn(mockReviewerRepository, 'find').mockResolvedValueOnce([reviewer]);
       // Treatment, then control
       jest.spyOn(Math, 'random').mockReturnValueOnce(0.3).mockReturnValueOnce(0.6);
 
@@ -284,6 +292,24 @@ describe('SurveyService', () => {
       lastName: 'Omega',
     };
 
+    const youth1 = {
+      id: 10,
+      uuid: 'youth1',
+      email: 'gamma@gmail.com',
+      firstName: 'Gamma',
+      lastName: 'Delta',
+    };
+
+    const youth2 = {
+      id: 11,
+      uuid: 'youth2',
+      email: 'kappa@gmail.com',
+      firstName: 'Kappa',
+      lastName: 'Iota',
+    };
+
+    mockYouthRepository.find = jest.fn().mockResolvedValue([youth1, youth2]);
+
     mockReviewerRepository.save(reviewer1);
     mockReviewerRepository.save(reviewer2);
 
@@ -317,6 +343,8 @@ describe('SurveyService', () => {
         },
       ],
     };
+
+    mockReviewerRepository.find = jest.fn().mockResolvedValue([reviewer1, reviewer2]);
 
     await service.createBatchAssignments(dto);
     await service.sendEmailToReviewersInBatchAssignment(dto);

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -171,7 +171,9 @@ export class SurveyService {
         const youth = youthMap.get(pair.youth.email);
 
         if (!reviewer || !youth) {
-          throw new Error(`Reviewer or Youth not found for email: ${pair.reviewer.email}, ${pair.youth.email}`);
+          throw new Error(
+            `Reviewer or Youth not found for email: ${pair.reviewer.email}, ${pair.youth.email}`,
+          );
         }
 
         return {
@@ -182,7 +184,6 @@ export class SurveyService {
         };
       }),
     );
-
   }
 
   /**

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -161,17 +161,28 @@ export class SurveyService {
       this.youthRepository.find({ where: { email: In(youthEmails) } }),
     ]);
 
-    // If we get here, then none of the given reviewer-youth pairs should exist for this survey
+    // Create a lookup by email
+    const reviewerMap = new Map(reviewerEntities.map((r) => [r.email, r]));
+    const youthMap = new Map(youthEntities.map((y) => [y.email, y]));
+
     await this.assignmentRepository.save(
-      dto.pairs.map((_, i) => {
+      dto.pairs.map((pair) => {
+        const reviewer = reviewerMap.get(pair.reviewer.email);
+        const youth = youthMap.get(pair.youth.email);
+
+        if (!reviewer || !youth) {
+          throw new Error(`Reviewer or Youth not found for email: ${pair.reviewer.email}, ${pair.youth.email}`);
+        }
+
         return {
           survey,
-          reviewer: reviewerEntities[i],
-          youth: youthEntities[i],
+          reviewer,
+          youth,
           responses: [],
         };
       }),
     );
+
   }
 
   /**


### PR DESCRIPTION
### ℹ️ Issue

Closes #114

### 📝 Description

Briefly list the changes made to the code:

- Map reviewers and youth by email rather than looking them up based off of indexes

### ✔️ Verification

Verified by running the route with the body provided in the ticket through postman, and confirmed that proper reviewers are assigned in pg admin

<img width="613" height="111" alt="Screenshot 2025-07-12 at 1 23 45 PM" src="https://github.com/user-attachments/assets/4e2dbfbd-acb9-4c44-b15f-295fb17a88d2" />

<img width="955" height="562" alt="Screenshot 2025-07-12 at 1 23 54 PM" src="https://github.com/user-attachments/assets/f4b4d7c7-3b01-4eea-adf4-943149c2156f" />


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
