### PR TITLE
added paragraph entity and migration

### DIFF
--- a/migrations/1753377136366-Add Paragraph Entity.ts
+++ b/migrations/1753377136366-Add Paragraph Entity.ts
@@ -1,0 +1,34 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddParagraphEntity1753377136366 implements MigrationInterface {
+    name = 'AddParagraphEntity1753377136366'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        CREATE TABLE "paragraph" (
+            "id" SERIAL NOT NULL,
+            "order" INTEGER NOT NULL,
+            "templateId" INTEGER,
+            CONSTRAINT "PK_paragraph_id" PRIMARY KEY ("id"),
+            CONSTRAINT "FK_paragraph_template" FOREIGN KEY ("templateId") REFERENCES "survey_template"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )
+    `);
+
+        await queryRunner.query(`
+        CREATE TABLE "paragraph_sentences" (
+            "paragraphId" integer NOT NULL,
+            "sentenceId" integer NOT NULL,
+            CONSTRAINT "PK_paragraph_sentences" PRIMARY KEY ("paragraphId", "sentenceId"),
+            CONSTRAINT "FK_paragraphId" FOREIGN KEY ("paragraphId") REFERENCES "paragraph"("id") ON DELETE CASCADE,
+            CONSTRAINT "FK_sentenceId" FOREIGN KEY ("sentenceId") REFERENCES "sentence"("id") ON DELETE CASCADE
+        )
+        `);
+
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "paragraph"`);
+        await queryRunner.query(`DROP TABLE "paragraph_sentences"`);
+
+    }
+}

--- a/migrations/1753377136366-Add Paragraph Entity.ts
+++ b/migrations/1753377136366-Add Paragraph Entity.ts
@@ -1,10 +1,10 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddParagraphEntity1753377136366 implements MigrationInterface {
-    name = 'AddParagraphEntity1753377136366'
+  name = 'AddParagraphEntity1753377136366';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
         CREATE TABLE "paragraph" (
             "id" SERIAL NOT NULL,
             "order" INTEGER NOT NULL,
@@ -14,7 +14,7 @@ export class AddParagraphEntity1753377136366 implements MigrationInterface {
     )
     `);
 
-        await queryRunner.query(`
+    await queryRunner.query(`
         CREATE TABLE "paragraph_sentences" (
             "paragraphId" integer NOT NULL,
             "sentenceId" integer NOT NULL,
@@ -23,12 +23,10 @@ export class AddParagraphEntity1753377136366 implements MigrationInterface {
             CONSTRAINT "FK_sentenceId" FOREIGN KEY ("sentenceId") REFERENCES "sentence"("id") ON DELETE CASCADE
         )
         `);
+  }
 
-    }
-
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP TABLE "paragraph"`);
-        await queryRunner.query(`DROP TABLE "paragraph_sentences"`);
-
-    }
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "paragraph"`);
+    await queryRunner.query(`DROP TABLE "paragraph_sentences"`);
+  }
 }

--- a/src/paragraph/types/paragraph.entity.ts
+++ b/src/paragraph/types/paragraph.entity.ts
@@ -1,6 +1,15 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn, JoinColumn, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  JoinColumn,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 import { Sentence } from 'src/sentence/types/sentence.entity';
-import {SurveyTemplate} from 'src/surveyTemplate/types/surveyTemplate.entity'
+import { SurveyTemplate } from 'src/surveyTemplate/types/surveyTemplate.entity';
 
 @Entity()
 export class Paragraph {

--- a/src/paragraph/types/paragraph.entity.ts
+++ b/src/paragraph/types/paragraph.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, OneToOne, PrimaryGeneratedColumn, JoinColumn, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import { Sentence } from 'src/sentence/types/sentence.entity';
+import {SurveyTemplate} from 'src/surveyTemplate/types/surveyTemplate.entity'
+
+@Entity()
+export class Paragraph {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  order: number;
+
+  @ManyToOne(() => SurveyTemplate)
+  template: SurveyTemplate;
+
+  @ManyToMany(() => Sentence)
+  @JoinTable()
+  sentences: Sentence[];
+}

--- a/src/sentence/types/sentence.entity.ts
+++ b/src/sentence/types/sentence.entity.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn, JoinColumn, ManyToMany, JoinTable } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  JoinColumn,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 import { Question } from '../../question/types/question.entity';
 import { Paragraph } from 'src/paragraph/types/paragraph.entity';
 

--- a/src/sentence/types/sentence.entity.ts
+++ b/src/sentence/types/sentence.entity.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn, JoinColumn } from 'typeorm';
+import { Column, Entity, OneToOne, PrimaryGeneratedColumn, JoinColumn, ManyToMany, JoinTable } from 'typeorm';
 import { Question } from '../../question/types/question.entity';
+import { Paragraph } from 'src/paragraph/types/paragraph.entity';
 
 @Entity()
 export class Sentence {

--- a/src/surveyTemplate/types/surveyTemplate.entity.ts
+++ b/src/surveyTemplate/types/surveyTemplate.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { User } from '../../user/types/user.entity';
 import { Question } from '../../question/types/question.entity';
+import { Paragraph } from 'src/paragraph/types/paragraph.entity';
 
 @Entity()
 export class SurveyTemplate {
@@ -14,6 +15,6 @@ export class SurveyTemplate {
     cascade: true,
   })
   questions: Question[];
-
+  
   name: string;
 }

--- a/src/surveyTemplate/types/surveyTemplate.entity.ts
+++ b/src/surveyTemplate/types/surveyTemplate.entity.ts
@@ -15,6 +15,6 @@ export class SurveyTemplate {
     cascade: true,
   })
   questions: Question[];
-  
+
   name: string;
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes https://github.com/Code-4-Community/jpal-backend/issues/127 

### 📝 Description

- created paragraph entity with order column and appropriate relationships
- generated and applied migration, which included creating a junction table for the many-to-many relationship between paragraphs and sentences

### ✔️ Verification

N/A

### 🏕️ (Optional) Future Work / Notes
- nothing really, but not sure if we should have survey templates refer back to the paragraphs (currently, there is only a foreign key in the paragraphs entity that references a survey template)
