### PR TITLE
Ensure you can open in progress surveys

### DIFF
--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -298,7 +298,7 @@ export class SurveyService {
 
     const assignmentsForReviewer = survey.assignments.filter(
       (assignment) =>
-        assignment.reviewer.id === reviewer.id && assignment.status === AssignmentStatus.INCOMPLETE,
+        assignment.reviewer.id === reviewer.id && assignment.status !== AssignmentStatus.COMPLETED,
     );
 
     if (assignmentsForReviewer.length === 0) {


### PR DESCRIPTION
### ℹ️ Issue

Closes #157 
### 📝 Description

Briefly list the changes made to the code:

- Ensured that only completed surveys cannot be opened

### ✔️ Verification

- Successfully opened an incomplete survey
- Successfully opened an in-progress survey
- Unsuccessfully opened a completed survey

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
