### PR TITLE
added platform admin role

### DIFF
--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, mixin } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { Role } from '../../user/types/role';
 import { PossiblyAuthorizedRequest } from '../types/authorized-request';
+import { ROLE_HIERARCHY } from '../../user/types/role';
 
 /**
  * Returns a Guard that only allows Users with the given roles to access the route.
@@ -13,7 +14,10 @@ const RolesGuard = (roles: Role[]): any => {
     canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
       const req = context.switchToHttp().getRequest<PossiblyAuthorizedRequest>();
       if (!req.user) return false;
-      return roles.includes(req.user.role);
+
+      const userPermissions = ROLE_HIERARCHY[req.user.role] || [req.user.role];
+
+      return roles.some((role) => userPermissions.includes(role));
     }
   }
 

--- a/src/auth/types/authorized-request.ts
+++ b/src/auth/types/authorized-request.ts
@@ -1,4 +1,3 @@
-import Request from 'express';
 import { User } from '../../user/types/user.entity';
 
 export type PossiblyAuthorizedRequest = Request & {

--- a/src/user/types/role.ts
+++ b/src/user/types/role.ts
@@ -1,4 +1,11 @@
 export enum Role {
   RESEARCHER = 'researcher',
   ADMIN = 'admin',
+  PLATFORM_ADMIN = 'platform_admin',
 }
+
+export const ROLE_HIERARCHY = {
+  [Role.PLATFORM_ADMIN]: [Role.RESEARCHER, Role.ADMIN],
+  [Role.ADMIN]: [Role.ADMIN],
+  [Role.RESEARCHER]: [Role.RESEARCHER],
+};

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -13,6 +13,15 @@ const mockUser: User = {
   createdDate: new Date('2023-09-24'),
 };
 
+const mockUserResearcher: User = {
+  id: 1,
+  email: 'test@test.com',
+  firstName: 'test',
+  lastName: 'user',
+  role: Role.RESEARCHER,
+  createdDate: new Date('2023-09-24'),
+};
+
 const listMockUsers: User[] = [mockUser];
 
 const serviceMock: Partial<UserService> = {
@@ -40,18 +49,22 @@ describe('UsersController', () => {
   it('should delegate user creation to the users service', async () => {
     expect.assertions(2);
     expect(
-      await controller.create({
-        email: mockUser.email,
-        firstName: mockUser.firstName,
-        lastName: mockUser.lastName,
-        role: mockUser.role,
-      }),
+      await controller.create(
+        {
+          email: mockUser.email,
+          firstName: mockUser.firstName,
+          lastName: mockUser.lastName,
+          role: mockUser.role,
+        },
+        mockUserResearcher,
+      ),
     ).toEqual(mockUser);
     expect(serviceMock.create).toHaveBeenCalledWith(
       mockUser.email,
       mockUser.firstName,
       mockUser.lastName,
       mockUser.role,
+      false,
     );
   });
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -4,6 +4,7 @@ import { User } from './types/user.entity';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CreateUserRequestDto } from './dto/create-user.dto';
 import { UserService } from './user.service';
+import { ReqUser } from '../auth/decorators/user.decorator';
 
 @Controller('user')
 export class UserController {
@@ -14,12 +15,13 @@ export class UserController {
    */
   @Post()
   @Auth(Role.RESEARCHER)
-  create(@Body() createUserRequestDto: CreateUserRequestDto): Promise<User> {
+  create(@Body() createUserRequestDto: CreateUserRequestDto, @ReqUser() user: User): Promise<User> {
     return this.userService.create(
       createUserRequestDto.email,
       createUserRequestDto.firstName,
       createUserRequestDto.lastName,
       createUserRequestDto.role,
+      user.role === Role.PLATFORM_ADMIN,
     );
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -12,7 +12,19 @@ export class UserService {
     private awsCreateUser: AwsCreateUserService,
   ) {}
 
-  async create(email: string, firstName: string, lastName: string, role: Role): Promise<User> {
+  async create(
+    email: string,
+    firstName: string,
+    lastName: string,
+    role: Role,
+    isPlatformAdmin: boolean,
+  ): Promise<User> {
+    if ((role === Role.PLATFORM_ADMIN || role === Role.RESEARCHER) && !isPlatformAdmin) {
+      throw new ConflictException(
+        'Only platform admins can create researcher and platform admin users',
+      );
+    }
+
     const emailNotUnique = await this.userRepository.findOne({ email });
     if (!!emailNotUnique) throw new ConflictException('Email already exists');
     try {


### PR DESCRIPTION
### ℹ️ Issue

Closes #156

### 📝 Description

- Added a new user type called platform admin
- Gave platform admins all permissions that researchers have
- altered create user route to ensure that only platform admins can create new platform admins and researchers

### ✔️ Verification

- Added unit tests to check that only platform admins can create researchers 
- ran through survey cycle to make sure all still works there

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
